### PR TITLE
Cleanup ExpDirOps and devconfig

### DIFF
--- a/expworkup/createjson.py
+++ b/expworkup/createjson.py
@@ -173,7 +173,7 @@ def ExpDirOps(local_directory, debug):
         modlog.info('Pulling from MIT datafolder')
         remote_directory = '1VNsWClt-ppg8ojUztDYssnSgfoe9XRhi'
 
-    crys_UIDs, robo_UIDs, exp_UIDs, drive_run_dirnames = googleio.get_drive_UIDs(remote_directory)
+    observation_UIDs, exp_volume_UIDs, prep_UIDs, drive_run_dirnames = googleio.get_drive_UIDs(remote_directory)
 
     # todo: what to do with these log statements? Do we drop this vocabulary
     # modlog.info('parsing EXPERIMENTAL_OBJECT')
@@ -207,9 +207,9 @@ def ExpDirOps(local_directory, debug):
                     Something like: 
                     UIDs = {'run_name': {'crys': str, 'robo': str, 'exp': str}}
                     """
-                    googleio.download_run_data(crys_UIDs[drive_run_dirname],
-                                               robo_UIDs[drive_run_dirname],
-                                               exp_UIDs[drive_run_dirname],
+                    googleio.download_run_data(observation_UIDs[drive_run_dirname],
+                                               exp_volume_UIDs[drive_run_dirname],
+                                               prep_UIDs[drive_run_dirname],
                                                workdir,
                                                drive_run_dirname)
 

--- a/expworkup/createjson.py
+++ b/expworkup/createjson.py
@@ -23,29 +23,28 @@ WorkupVersion = 1.0
 modlog = logging.getLogger('report.CreateJSON')
 
 
-def parse_preparation_interface(local_ExpDataEntry_json):
+def parse_preparation_interface(fname):
     """
 
-    :param local_ExpDataEntry_json:
+    :param fname:
     :return:
     """
-    with open(local_ExpDataEntry_json, "r") as f:
+    with open(fname, "r") as f:
         exp_dict = json.load(f)
         exp_str = json.dumps(exp_dict, indent=4, sort_keys=True)
     exp_str = exp_str[:-8]  # todo Ian: why? this needs to be documented
     return exp_str, exp_dict
 
 
-def parse_exp_volumes(robotfile, robotfile1):
+def parse_exp_volumes(fname):
     """
 
-    :param robotfile:
+    :param fname:
     :return:
     """
     LAB = globals.get_lab()
-    # ooooh weeee that is some nasty code below, just looking for the right name
 
-    robot_dict = pd.read_excel(open(robotfile, 'rb'), header=[0], sheet_name=0)
+    robot_dict = pd.read_excel(open(fname, 'rb'), header=[0], sheet_name=0)
     reagentlist = []
     for header in robot_dict.columns:
         if config.lab_vars[LAB]['reagent_alias'] in header and "ul" in header:
@@ -55,17 +54,17 @@ def parse_exp_volumes(robotfile, robotfile1):
     if LAB == 'MIT_PVLab':
         rnum += 1
 
-    pipette_volumes = pd.read_excel(robotfile, sheet_name=0,
+    pipette_volumes = pd.read_excel(fname, sheet_name=0,
                                     usecols=range(0, rnum+2))
-    reaction_parameters = pd.read_excel(robotfile, sheet_name=0,
+    reaction_parameters = pd.read_excel(fname, sheet_name=0,
                                         usecols=[rnum+2, rnum+3]).dropna()
-    reagent_info = pd.read_excel(robotfile, sheet_name=0,
+    reagent_info = pd.read_excel(fname, sheet_name=0,
                                  usecols=[rnum+4, rnum+5, rnum+6, rnum+7]).dropna()
 
     pipette_dump = json.dumps(pipette_volumes.values.tolist())
     reaction_dump = json.dumps(reaction_parameters.values.tolist())
     reagent_dump = json.dumps(reagent_info.values.tolist())
-    
+
     return pipette_dump, reaction_dump, reagent_dump, pipette_volumes, reaction_parameters, reagent_info
 
 def parse_observation_interface(fname):

--- a/expworkup/devconfig.py
+++ b/expworkup/devconfig.py
@@ -60,6 +60,18 @@ lab_vars = {
             'reagent_alias': 'Reagent',
             'Robofile': '_RobotInput.xls'
         },
+    'ECL':
+        {
+            'template_folder': '131G45eK7o9ZiDb4a2yV7l2E1WVQrz16d',
+            'targetfolder': '11vIE3oGU77y38VRSu-OQQw2aWaNfmOHe',  # target folder for new experiments
+            'chemsheetid': '1JgRKUH_ie87KAXsC-fRYEw_5SepjOgVt7njjQBETxEg',
+            'chem_workbook_index': 0,
+            'reagentsheetid': '1JgRKUH_ie87KAXsC-fRYEw_5SepjOgVt7njjQBETxEg',
+            'reagent_workbook_index': 1,
+            'reagent_interface_amount_startrow': 15,
+            'reagent_alias': 'Reagent',
+            'Robofile': '_RobotInput.xls'
+        },
     'dev':
         {
             'template_folder': '1w5tReXSRvC6cm_rQy74-10QLIlG7Eee0',

--- a/expworkup/devconfig.py
+++ b/expworkup/devconfig.py
@@ -59,51 +59,19 @@ lab_vars = {
             'reagent_interface_amount_startrow': 15,
             'reagent_alias': 'Reagent',
             'Robofile': '_RobotInput.xls'
+        },
+    'dev':
+        {
+            'template_folder': '1w5tReXSRvC6cm_rQy74-10QLIlG7Eee0',
+            'targetfolder': '19nt2-9Inub8IEYDxOLnplCPDEYt1NPqZ', # this is 1 dev
+            'chemsheetid': '1uj6A3TH2oMSQwzhPapfmr1t-CbevEGmQjKIyfg9aSgk',
+            'chem_workbook_index': 0,
+            'reagentsheetid': '1uj6A3TH2oMSQwzhPapfmr1t-CbevEGmQjKIyfg9aSgk',
+            'reagent_workbook_index': 1,
+            'reagent_interface_amount_startrow': 16,
+            'reagent_alias': 'Reagent',
+            'max_reagents': 8,
+            'required_files': ['observation_interface', 'preparation_interface', 'metadata.json'],
+            'observation_interface': {'uid_col': 'F'}
         }
 }
-
-#######################################
-# Wolfram Kernel Management
-
-
-system = platform.system()
-if system == "Linux":
-    wolfram_kernel_path = None
-    from pathlib import Path
-    # try first path location
-    wolfram_kernel = Path('/usr/local/Wolfram/WolframEngine/12.0/Executables/WolframKernel')
-    if wolfram_kernel.is_file():
-        wolfram_kernel_path = "/usr/local/Wolfram/WolframEngine/12.0/Executables/WolframKernel"
-    # try second path location
-    wolfram_kernel_2 = Path('/usr/local/Wolfram/Mathematica/12.0/Executables/WolframKernel')
-    if wolfram_kernel_2.is_file():
-        wolfram_kernel_path = '/usr/local/Wolfram/Mathematica/12.0/Executables/WolframKernel'
-    if wolfram_kernel_path is None:
-        print('WolframKernel not successfully found, please correct devconfig')
-        import sys
-        sys.exit()
-# Mac
-elif system == "Darwin":
-    wolfram_kernel_path = None
-
-######################################
-# Sampler Selection
-
-
-# must be 'default' or 'wolfram'
-# 'wolfram' is currently experimental and unsupported
-sampler = 'wolfram'
-
-#######################################
-# Laboratory file management
-
-
-def labfiles(lab):
-    """Returns files that need to be sent to a given laboratory"""
-    if lab == "LBL" or lab == "HC":
-        filereq = ['CrystalScoring', 'ExpDataEntry', 'metadata.json']
-    if lab == "MIT_PVLab":
-        filereq = ['observation_interface', 'preparation_interface', 'metadata.json']
-    if lab == 'ECL':
-        filereq = ['CrystalScoring', 'metadata.json']
-    return filereq

--- a/expworkup/devconfig.py
+++ b/expworkup/devconfig.py
@@ -75,3 +75,11 @@ lab_vars = {
             'observation_interface': {'uid_col': 'F'}
         }
 }
+
+# valid interface filenames after download from gdrive
+
+valid_input_files = {
+    'preparation_interface': ['ExpDataEntry.json'],
+    'experiment_specification': ['ExperimentSpecification.xls', 'RobotInput.xls'],
+    'observation_interface': ['observation_interface.csv', 'CrystalScoring.csv']
+}

--- a/expworkup/googleio.py
+++ b/expworkup/googleio.py
@@ -62,7 +62,7 @@ def get_drive_UIDs(remote_directory):
     remote_directory_children = drive.ListFile({'q': "'%s' in parents and trashed=false" % remote_directory}).GetList()
 
     # get all of the CrystalScoring, ExpDataEntry, and RobotInput file UIDs in child directory
-    print('Downloading data ..', end='', flush=True)
+    print('Retrieving relevant file pointers...')
     data_directories = []
     observation_interface_files = {}
     prep_interface_files = {}
@@ -86,7 +86,6 @@ def get_drive_UIDs(remote_directory):
                 if "RobotInput" in grandchild['title']\
                         or "ExperimentSpecification" in grandchild['title']:
                     pipette_volume_files[child['title']] = grandchild['id']
-    print(' download complete')
     return observation_interface_files, pipette_volume_files, prep_interface_files, data_directories
 
 

--- a/runme.py
+++ b/runme.py
@@ -2,6 +2,7 @@
 import logging
 import argparse as ap
 import os
+import sys
 
 
 from expworkup import jsontocsv

--- a/runme.py
+++ b/runme.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
         debug = 0
 
     initialize(args)
-    createjson.ExpDirOps(args.local_directory, debug)
+    createjson.download_experiment_directories(args.local_directory, debug)
     finalcsv = jsontocsv.printfinal(args.local_directory, debug, args.raw)
     if args.verdata == 1:
         export_to_repo.prepareexport(finalcsv, args.state, link)

--- a/utils/file_handling.py
+++ b/utils/file_handling.py
@@ -1,6 +1,7 @@
 import os
+import re
 
-from expworkup.devconfig import valid_input_files
+from expworkup.devconfig import valid_input_files, SUPPORTED_LABS
 
 
 def get_interface_filename(interface_type, working_directory, runID):
@@ -10,3 +11,18 @@ def get_interface_filename(interface_type, working_directory, runID):
             return filename
 
     raise FileNotFoundError(f'Could not find any of {valid_input_files[interface_type]} file for {runID}')
+
+
+def get_experimental_run_lab(run_filename):
+    """
+
+    :param run_filename: either the remote run directory name or the local json that is generated from it
+    :return: the labname
+    """
+    for lab in SUPPORTED_LABS:
+        lab_pat = re.compile(f'_({lab})($|.json$)')
+        match = lab_pat.search(run_filename.strip())
+        if match:
+            return match.group(1)
+
+    raise RuntimeError(f'{run_filename} does not specify a supported lab')

--- a/utils/file_handling.py
+++ b/utils/file_handling.py
@@ -1,0 +1,12 @@
+import os
+
+from expworkup.devconfig import valid_input_files
+
+
+def get_interface_filename(interface_type, working_directory, runID):
+    for suffix in valid_input_files[interface_type]:
+        filename = os.path.join(working_directory, f'{runID}_{suffix}')
+        if os.path.exists(filename):
+            return filename
+
+    raise FileNotFoundError(f'Could not find any of {valid_input_files[interface_type]} file for {runID}')


### PR DESCRIPTION
closes #41 

ExpDirOps: 
* rename to clarify intent
* clean up try/excepts: 
    * reduce usage of `try` from 3 to 1
    * make `except` more strict by parsing `gspread` response

`createjson.py`: 
* cleanup helper functions
* create funs in `utils` and vars in `devconfig` to extensively read interface files based on file presence

Devconfig: 
* remove unneeded code
* add `dev` lab
* add `valid_interface_filenames`

Utils: 
* see above under `createjson.py` point 2