### PR TITLE
Cleanup devconfig sampler handling

### DIFF
--- a/expworkup/devconfig.py
+++ b/expworkup/devconfig.py
@@ -146,32 +146,36 @@ workup_targets = {
 #######################################
 # Wolfram Kernel Management
 
+
+# first check that system is supported: do one thing at a time
+system = platform.system()
+if system not in ['Linux', 'Darwin', 'Windows']:
+    # Dont kill, just warn. If it dies, it dies. If it doesn't: cool!
+    print("Warning: OS not officially supported") 
+
+
 wolfram_kernel_path = None # ensure the value can be imported on all computers.
 
-system = platform.system()
-if system == "Linux":
-    wolfram_kernel_path = None
-    from pathlib import Path
-    # try first path location
-    wolfram_kernel = Path('/usr/local/Wolfram/WolframEngine/12.0/Executables/WolframKernel')
-    if wolfram_kernel.is_file():
-        wolfram_kernel_path = "/usr/local/Wolfram/WolframEngine/12.0/Executables/WolframKernel"
-    # try second path location
-    wolfram_kernel_2 = Path('/usr/local/Wolfram/Mathematica/12.0/Executables/WolframKernel')
-    if wolfram_kernel_2.is_file():
-        wolfram_kernel_path = '/usr/local/Wolfram/Mathematica/12.0/Executables/WolframKernel'
-    if wolfram_kernel_path is None:
-        print('WolframKernel not successfully found, please correct devconfig')
-        import sys
-        sys.exit()
-
+# we only need to do this check if the user wants wolfram in the first place
+if sampler == 'wolfram': 
+    if system == "Linux":
+        wolfram_kernel_path = None
+        from pathlib import Path
+        # try first path location
+        wolfram_kernel = Path('/usr/local/Wolfram/WolframEngine/12.0/Executables/WolframKernel')
+        if wolfram_kernel.is_file():
+            wolfram_kernel_path = "/usr/local/Wolfram/WolframEngine/12.0/Executables/WolframKernel"
+        # try second path location
+        wolfram_kernel_2 = Path('/usr/local/Wolfram/Mathematica/12.0/Executables/WolframKernel')
+        if wolfram_kernel_2.is_file():
+            wolfram_kernel_path = '/usr/local/Wolfram/Mathematica/12.0/Executables/WolframKernel'
+        if wolfram_kernel_path is None:
+            # is this allowed? maybe can do in a cleaner way but nice to automate this instead of just killing
+            print('Warning: WolframKernel not successfully found, falling back on default')
+            sampler = 'default' 
 # Mac or Windows
 elif system == "Darwin" or system == 'Windows':
     wolfram_kernel_path = None
-
-# Other
-else:
-    raise OSError("Your system is likely not supported if it's not Linux, MAC, or Windows")
 
 ###################################
 #Chemdescriptor management


### PR DESCRIPTION
I was testing out this dfdumping PR on my new Linux machine with no Wolfram installed. The way devconfig was setup required me to isntall Wolfram before running. This install takes half an hour. I dont have that time, and this shouldnt be a feature of the code anyway. 

Did some cleaning up. 

Major points: 
1. I made a few changes. Intent behind changes is documented in comments. take what you like, drop what you dont. 
2. Whatever you do keep should probably be moved over to Capture as well.
2.1 Does the Report code even need to know about the sampler? could just remove this part entirely from Report devconfig and only make changes in Capture. Of course you may want to keep them the same to keep things simple. Just my $.02